### PR TITLE
Allow using local insight-api node

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ transactions only, or both types.
     --btcd-rpc-user=<u> btcd rpc username.
     --btcd-rpc-pass=<p> btcd rpc password.
     
-    --insight=<url>     insight server. defaults to https://insight.bitpay.com
+    --insight=<url>     insight server. defaults to https://insight.bitpay.com/api
+                        use http://localhost:3001/insight-api for local node
     
     --addr-tx-limit=<n> per address transaction limit. default = 1000
     --testnet           use testnet. only affects addr validation.

--- a/bitprices.php
+++ b/bitprices.php
@@ -131,7 +131,7 @@ class bitprices {
         }
 
         if( !@$params['insight'] ) {
-            $params['insight'] = 'https://insight.bitpay.com';
+            $params['insight'] = 'https://insight.bitpay.com/api';
         }
         
         $params['toshi-fast'] = isset($params['toshi-fast']);
@@ -491,7 +491,8 @@ class bitprices {
     --btcd-rpc-user=<u> btcd rpc username.
     --btcd-rpc-pass=<p> btcd rpc password.
     
-    --insight=<url>     insight server. defaults to https://insight.bitpay.com
+    --insight=<url>     insight server. defaults to https://insight.bitpay.com/api
+                        use http://localhost:3001/insight-api for local node
     
     --addr-tx-limit=<n> per address transaction limit. default = 1000
     --testnet           use testnet. only affects addr validation.

--- a/lib/blockchain_api.php
+++ b/lib/blockchain_api.php
@@ -336,7 +336,7 @@ class blockchain_api_insight_multiaddr  {
         $addr_tx_limit = $params['addr-tx-limit'];
         $addrs = implode( ',', $addr_list );
         
-        $url_mask = "%s/api/addrs/%s/txs?from=0&to=%s";
+        $url_mask = "%s/addrs/%s/txs?from=0&to=%s";
         $url = sprintf( $url_mask, $params['insight'], $addrs, $addr_tx_limit );
         
         mylogger()->log( "Retrieving transactions from $url", mylogger::info );
@@ -496,7 +496,7 @@ class blockchain_api_insight  {
         // note:  insight /api/txs does not presently seem to support a limit.
         $addr_tx_limit = $params['addr-tx-limit'];
         
-        $url_mask = "%s/api/txs?address=%s";
+        $url_mask = "%s/txs?address=%s";
         $url = sprintf( $url_mask, $params['insight'], $addr );
         
         mylogger()->log( "Retrieving transactions from $url", mylogger::info );


### PR DESCRIPTION
The hardcoded url mask didn’t allow for local insight-api nodes.

You can now use -—insight=http://localhost:3001/insight-api to use a local node.
